### PR TITLE
Build info was causing issues because value not set.

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
@@ -23,11 +22,6 @@ func NewVersionCommand() *cobra.Command {
 			fmt.Printf("build date:  %s\n", BuildDate)
 			fmt.Printf("scm hash:    %s\n", BuildHash)
 			fmt.Printf("environment: %s\n", BuildEnvironment)
-
-			bi, ok := debug.ReadBuildInfo()
-			if ok && bi != nil {
-				fmt.Printf("go version:  %s\n", bi.GoVersion)
-			}
 		},
 	}
 


### PR DESCRIPTION
Build info was causing issues because value not set. Not needed for our fork.