### PR TITLE
Add option to ingore KMS errors due to permissions

### DIFF
--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -128,8 +128,8 @@ func (n *Nuke) Run() error {
 		time.Sleep(5 * time.Second)
 	}
 
-	fmt.Printf("Nuke complete: %d failed, %d skipped, %d finished.\n\n",
-		n.items.Count(ItemStateFailed), n.items.Count(ItemStateFiltered), n.items.Count(ItemStateFinished))
+	fmt.Printf("Nuke complete: %d failed, %d skipped, %d ignored, %d finished.\n\n",
+		n.items.Count(ItemStateFailed), n.items.Count(ItemStateFiltered), n.items.Count(ItemStateIgnored), n.items.Count(ItemStateFinished))
 
 	return nil
 }
@@ -264,15 +264,15 @@ func (n *Nuke) HandleQueue() {
 	}
 
 	fmt.Println()
-	fmt.Printf("Removal requested: %d waiting, %d failed, %d skipped, %d finished\n\n",
+	fmt.Printf("Removal requested: %d waiting, %d failed, %d skipped, %d ignored, %d finished\n\n",
 		n.items.Count(ItemStateWaiting, ItemStatePending), n.items.Count(ItemStateFailed),
-		n.items.Count(ItemStateFiltered), n.items.Count(ItemStateFinished))
+		n.items.Count(ItemStateFiltered), n.items.Count(ItemStateIgnored), n.items.Count(ItemStateFinished))
 }
 
 func (n *Nuke) HandleRemove(item *Item) {
 	err := item.Resource.Remove()
 	if err != nil && err.Error() == "ignoring error" {
-		item.State = ItemStateFinished
+		item.State = ItemStateIgnored
 		item.Reason = ""
 		return
 	} else if err != nil {

--- a/cmd/nuke.go
+++ b/cmd/nuke.go
@@ -271,7 +271,11 @@ func (n *Nuke) HandleQueue() {
 
 func (n *Nuke) HandleRemove(item *Item) {
 	err := item.Resource.Remove()
-	if err != nil {
+	if err != nil && err.Error() == "ignoring error" {
+		item.State = ItemStateFinished
+		item.Reason = ""
+		return
+	} else if err != nil {
 		item.State = ItemStateFailed
 		item.Reason = err.Error()
 		return

--- a/cmd/queue.go
+++ b/cmd/queue.go
@@ -16,6 +16,7 @@ const (
 	ItemStateFailed
 	ItemStateFiltered
 	ItemStateFinished
+	ItemStateIgnored
 )
 
 // An Item describes an actual AWS resource entity with the current state and
@@ -44,6 +45,8 @@ func (i *Item) Print() {
 		Log(i.Region, i.Type, i.Resource, ReasonSkip, i.Reason)
 	case ItemStateFinished:
 		Log(i.Region, i.Type, i.Resource, ReasonSuccess, "removed")
+	case ItemStateIgnored:
+		Log(i.Region, i.Type, i.Resource, ReasonSuccess, "ignored")
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,7 @@ type FeatureFlags struct {
 	DisableDeletionProtection        DisableDeletionProtection `yaml:"disable-deletion-protection"`
 	DisableEC2InstanceStopProtection bool                      `yaml:"disable-ec2-instance-stop-protection"`
 	ForceDeleteLightsailAddOns       bool                      `yaml:"force-delete-lightsail-addons"`
+	DisableFailOnKMSError            bool                      `yaml:"disable-fail-on-kms-error"`
 }
 
 type DisableDeletionProtection struct {

--- a/resources/kms-aliases.go
+++ b/resources/kms-aliases.go
@@ -6,12 +6,15 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/config"
 	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
 )
 
 type KMSAlias struct {
 	svc  *kms.KMS
 	name string
+
+	featureFlags config.FeatureFlags
 }
 
 func init() {
@@ -48,11 +51,19 @@ func (e *KMSAlias) Remove() error {
 	_, err := e.svc.DeleteAlias(&kms.DeleteAliasInput{
 		AliasName: &e.name,
 	})
+	if e.featureFlags.DisableFailOnKMSError && err != nil {
+		fmt.Printf("Ignoring KMSAlias Remove error: %s\n", err.Error())
+		return fmt.Errorf("ignoring error")
+	}
 	return err
 }
 
 func (e *KMSAlias) String() string {
 	return e.name
+}
+
+func (e *KMSAlias) FeatureFlags(ff config.FeatureFlags) {
+	e.featureFlags = ff
 }
 
 func (e *KMSAlias) Properties() types.Properties {

--- a/resources/kms-keys.go
+++ b/resources/kms-keys.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/config"
 	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
 )
 
@@ -15,6 +16,8 @@ type KMSKey struct {
 	state   string
 	manager *string
 	tags    []*kms.Tag
+
+	featureFlags config.FeatureFlags
 }
 
 func init() {
@@ -102,11 +105,19 @@ func (e *KMSKey) Remove() error {
 		KeyId:               &e.id,
 		PendingWindowInDays: aws.Int64(7),
 	})
+	if e.featureFlags.DisableFailOnKMSError && err != nil {
+		fmt.Printf("Ignoring KMSKey Remove error: %s\n", err.Error())
+		return fmt.Errorf("ignoring error")
+	}
 	return err
 }
 
 func (e *KMSKey) String() string {
 	return e.id
+}
+
+func (e *KMSKey) FeatureFlags(ff config.FeatureFlags) {
+	e.featureFlags = ff
 }
 
 func (i *KMSKey) Properties() types.Properties {


### PR DESCRIPTION
KMS errors are typically permissions related and much harder to fix than normal (usually involved around unrecoverable keys)

Add option to ignore KMS errors after trying a delete.