### PR TITLE
AWS SageMaker Nuke Process Update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/aws/aws-sdk-go v1.53.15
-	github.com/aws/aws-sdk-go-v2 v1.30.3
+	github.com/aws/aws-sdk-go-v2 v1.32.2
 	github.com/aws/aws-sdk-go-v2/config v1.27.22
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.22
 	github.com/aws/aws-sdk-go-v2/service/appstream v1.37.0
@@ -14,7 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.23.3
-	github.com/aws/smithy-go v1.20.3
+	github.com/aws/smithy-go v1.22.0
 	github.com/fatih/color v1.17.0
 	github.com/google/uuid v1.6.0
 	github.com/mb0/glob v0.0.0-20160210091149-1eb79d2de6c4
@@ -30,11 +30,12 @@ require (
 
 require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.8 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.15 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.15 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.21 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.14 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.2
 	github.com/aws/aws-sdk-go-v2/service/sso v1.22.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/aws/aws-sdk-go v1.53.15 h1:FtZmkg7xM8RfP2oY6p7xdKBYrRgkITk9yve2QV7N93
 github.com/aws/aws-sdk-go v1.53.15/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.30.3 h1:jUeBtG0Ih+ZIFH0F4UkmL9w3cSpaMv9tYYDbzILP8dY=
 github.com/aws/aws-sdk-go-v2 v1.30.3/go.mod h1:nIQjQVp5sfpQcTc9mPSr1B0PaWK5ByX9MOoDadSN4lc=
+github.com/aws/aws-sdk-go-v2 v1.32.2 h1:AkNLZEyYMLnx/Q/mSKkcMqwNFXMAvFto9bNsHqcTduI=
+github.com/aws/aws-sdk-go-v2 v1.32.2/go.mod h1:2SK5n0a2karNTv5tbP1SjsX0uhttou00v/HpXKM1ZUo=
 github.com/aws/aws-sdk-go-v2/config v1.27.22 h1:TRkQVtpDINt+Na/ToU7iptyW6U0awAwJ24q4XN+59k8=
 github.com/aws/aws-sdk-go-v2/config v1.27.22/go.mod h1:EYY3mVgFRUWkh6QNKH64MdyKs1YSUgatc0Zp3MDxi7c=
 github.com/aws/aws-sdk-go-v2/credentials v1.17.22 h1:wu9kXQbbt64ul09v3ye4HYleAr4WiGV/uv69EXKDEr0=
@@ -10,8 +12,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.8 h1:FR+oWPFb/8qMVYMWN98bUZA
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.8/go.mod h1:EgSKcHiuuakEIxJcKGzVNWh5srVAQ3jKaSrBGRYvM48=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.15 h1:SoNJ4RlFEQEbtDcCEt+QG56MY4fm4W8rYirAmq+/DdU=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.15/go.mod h1:U9ke74k1n2bf+RIgoX1SXFed1HLs51OgUSs+Ph0KJP8=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.21 h1:UAsR3xA31QGf79WzpG/ixT9FZvQlh5HY1NRqSHBNOCk=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.21/go.mod h1:JNr43NFf5L9YaG3eKTm7HQzls9J+A9YYcGI5Quh1r2Y=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.15 h1:C6WHdGnTDIYETAm5iErQUiVNsclNx9qbJVPIt03B6bI=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.15/go.mod h1:ZQLZqhcu+JhSrA9/NXRm8SkDvsycE+JkV3WGY41e+IM=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.21 h1:6jZVETqmYCadGFvrYEQfC5fAQmlo80CeL5psbno6r0s=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.21/go.mod h1:1SR0GbLlnN3QUmYaflZNiH1ql+1qrSiB2vwcJ+4UM60=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 h1:hT8rVHwugYE2lEfdFE0QWVo81lF7jMrYJVDWI+f+VxU=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0/go.mod h1:8tu/lYfQfFe6IGnaOdrpVgEL2IrrDOf6/m9RQum4NkY=
 github.com/aws/aws-sdk-go-v2/service/appstream v1.37.0 h1:novlmw4mzemK9FHfneoni0pG0eCPISgeW72apbWSxdY=
@@ -28,6 +34,8 @@ github.com/aws/aws-sdk-go-v2/service/kafka v1.35.3 h1:MUx27PrqicGxgsiDWo7xv/Zsl4
 github.com/aws/aws-sdk-go-v2/service/kafka v1.35.3/go.mod h1:mBWO7tOHjEvfZ88cUBhCfViO9vclCumFcTeiR1cB4IA=
 github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.40.0 h1:ZKjJJWxZ4cGM6LWxXsnviGlBpqPvifSod4U8gOXik9U=
 github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.40.0/go.mod h1:23qyfghRkv9qOMRIL9KdUHiKyhARU/0FddRMtvMSVV0=
+github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.2 h1:/mvx8K7AB30O72duJz50Mk0trHKSjKYO8brwfRZdBEo=
+github.com/aws/aws-sdk-go-v2/service/sagemaker v1.163.2/go.mod h1:E9df73nTPKAoYe00vogXWwAXo2t2juosaKrwTrw+5h8=
 github.com/aws/aws-sdk-go-v2/service/sso v1.22.0 h1:lPIAPCRoJkmotLTU/9B6icUFlYDpEuWjKeL79XROv1M=
 github.com/aws/aws-sdk-go-v2/service/sso v1.22.0/go.mod h1:lcQG/MmxydijbeTOp04hIuJwXGWPZGI3bwdFDGRTv14=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.0 h1:/4r71ghx+hX9spr884cqXHPEmPzqH/J3K7fkE1yfcmw=
@@ -38,6 +46,8 @@ github.com/aws/aws-sdk-go-v2/service/wafregional v1.23.3 h1:7dr6En0/6KRFoz8VmnYk
 github.com/aws/aws-sdk-go-v2/service/wafregional v1.23.3/go.mod h1:24TtlRsv4LKAE3VnRJQhpatr8cpX0yj8NSzg8/lxOCw=
 github.com/aws/smithy-go v1.20.3 h1:ryHwveWzPV5BIof6fyDvor6V3iUL7nTfiTKXHiW05nE=
 github.com/aws/smithy-go v1.20.3/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
+github.com/aws/smithy-go v1.22.0 h1:uunKnWlcoL3zO7q+gG2Pk53joueEOsnNB28QdMsmiMM=
+github.com/aws/smithy-go v1.22.0/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/resources/sagemaker-algorithms.go
+++ b/resources/sagemaker-algorithms.go
@@ -1,0 +1,68 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type SageMakerAlgorithm struct {
+	svc           *sagemaker.SageMaker
+	algorithmName *string
+}
+
+func init() {
+	register("SageMakerAlgorithm", ListSageMakerAlgorithms)
+}
+
+func ListSageMakerAlgorithms(sess *session.Session) ([]Resource, error) {
+
+	svc := sagemaker.New(sess)
+	resources := []Resource{}
+
+	params := &sagemaker.ListAlgorithmsInput{
+		MaxResults: aws.Int64(30),
+	}
+
+	for {
+		resp, err := svc.ListAlgorithms(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, algorithm := range resp.AlgorithmSummaryList {
+			resources = append(resources, &SageMakerAlgorithm{
+				svc:           svc,
+				algorithmName: algorithm.AlgorithmName,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *SageMakerAlgorithm) Remove() error {
+
+	_, err := f.svc.DeleteAlgorithm(&sagemaker.DeleteAlgorithmInput{
+		AlgorithmName: f.algorithmName,
+	})
+
+	return err
+}
+
+func (f *SageMakerAlgorithm) String() string {
+	return *f.algorithmName
+}
+
+func (f *SageMakerAlgorithm) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("AlgorithmName", f.algorithmName)
+	return properties
+}

--- a/resources/sagemaker-spaces.go
+++ b/resources/sagemaker-spaces.go
@@ -1,0 +1,116 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type SageMakerSpace struct {
+	svc       *sagemaker.SageMaker
+	spaceName *string
+	domainID  *string
+}
+
+type SageMakerAppDelete struct {
+	svc       *sagemaker.SageMaker
+	appName   *string
+	domainID  *string
+	appType   *string
+	spaceName *string
+}
+
+func init() {
+	register("SageMakerSpaces", ListSageMakerSpaces)
+}
+
+func ListSageMakerSpaces(sess *session.Session) ([]Resource, error) {
+	svc := sagemaker.New(sess)
+	resources := []Resource{}
+
+	params := &sagemaker.ListSpacesInput{
+		MaxResults: aws.Int64(30),
+	}
+
+	for {
+		resp, err := svc.ListSpaces(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, space := range resp.Spaces {
+			resources = append(resources, &SageMakerSpace{
+				svc:       svc,
+				spaceName: space.SpaceName,
+				domainID:  space.DomainId,
+			})
+			deleteAppsInSpace(sess, *space.DomainId, *space.SpaceName, svc)
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *SageMakerSpace) Remove() error {
+
+	_, err := f.svc.DeleteSpace(&sagemaker.DeleteSpaceInput{
+		SpaceName: f.spaceName,
+		DomainId:  f.domainID,
+	})
+
+	return err
+}
+
+func (f *SageMakerSpace) String() string {
+	return *f.spaceName
+}
+
+func deleteAppsInSpace(sess *session.Session, DomainId string, SpaceName string, svc *sagemaker.SageMaker) error {
+	input := &sagemaker.ListAppsInput{
+		DomainIdEquals:  &DomainId,
+		SpaceNameEquals: &SpaceName,
+		MaxResults:      aws.Int64(30),
+	}
+	svc = sagemaker.New(sess)
+	for {
+		resp, err := svc.ListApps(input)
+		if err != nil {
+			return err
+		}
+
+		for _, app := range resp.Apps {
+			_, err := svc.DeleteApp(&sagemaker.DeleteAppInput{
+				DomainId:  app.DomainId,
+				AppName:   app.AppName,
+				AppType:   app.AppType,
+				SpaceName: app.SpaceName,
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		input.NextToken = resp.NextToken
+	}
+
+	return nil
+
+}
+
+func (f *SageMakerSpace) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("SpaceName", f.spaceName)
+	properties.Set("DomainId", f.domainID)
+	return properties
+}

--- a/resources/sagemaker-trainingjobs.go
+++ b/resources/sagemaker-trainingjobs.go
@@ -1,0 +1,67 @@
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/rebuy-de/aws-nuke/v2/pkg/types"
+)
+
+type SageMakerTrainingJob struct {
+	svc             *sagemaker.SageMaker
+	trainingJobName *string
+}
+
+func init() {
+	register("SageMakerTrainingJob", ListSageMakerTrainingJobs)
+}
+
+func ListSageMakerTrainingJobs(sess *session.Session) ([]Resource, error) {
+	svc := sagemaker.New(sess)
+	resources := []Resource{}
+
+	params := &sagemaker.ListTrainingJobsInput{
+		MaxResults: aws.Int64(30),
+	}
+
+	for {
+		resp, err := svc.ListTrainingJobs(params)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, trainingJob := range resp.TrainingJobSummaries {
+			resources = append(resources, &SageMakerTrainingJob{
+				svc:             svc,
+				trainingJobName: trainingJob.TrainingJobName,
+			})
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params.NextToken = resp.NextToken
+	}
+
+	return resources, nil
+}
+
+func (f *SageMakerTrainingJob) Remove() error {
+
+	_, err := f.svc.StopTrainingJob(&sagemaker.StopTrainingJobInput{
+		TrainingJobName: f.trainingJobName,
+	})
+
+	return err
+}
+
+func (f *SageMakerTrainingJob) String() string {
+	return *f.trainingJobName
+}
+
+func (f *SageMakerTrainingJob) Properties() types.Properties {
+	properties := types.NewProperties()
+	properties.Set("TrainingJobName", f.trainingJobName)
+	return properties
+}


### PR DESCRIPTION
1. In order to delete Domains and UserProfiles, the associated Spaces needs to be deleted. (sagemaker-spaces.go takes care of it).
2. The Spaces can have associated Apps which needs to be deleted first. (sagemaker-spaces.go takes care of it).
3. The Algorithms needs to be deleted first. (sagemaker-algorithms.go takes care of it).
4. After deleting the Algorithms, we can delete the Training Jobs. (sagemaker-trainingjobs.go takes care of it).